### PR TITLE
workflows: fix update to actions v4

### DIFF
--- a/.github/workflows/build-app.yml
+++ b/.github/workflows/build-app.yml
@@ -31,7 +31,7 @@ jobs:
                 curl -fsSL https://deb.nodesource.com/setup_14.x | bash -
                 apt-get install -y nodejs
           - name: Checkout esp-mqtt
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
           - name: ccache
             uses: hendrikmuhs/ccache-action@v1.2
             with:
@@ -46,7 +46,7 @@ jobs:
               cp -r . $IDF_PATH/components/mqtt/esp-mqtt
               IDF_CCACHE_ENABLE=1 idf-build-apps build --config-file ci/idf_build_apps.toml -p ${{inputs.app_path}} -t ${{inputs.target}}
           - name: Upload files to artifacts for run-target job
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             if: ${{inputs.upload_artifacts}}
             with:
               name: mqtt_bin_${{inputs.target}}_${{ inputs.idf_version }}_${{ inputs.app_name }}

--- a/.github/workflows/mqtt__host-tests.yml
+++ b/.github/workflows/mqtt__host-tests.yml
@@ -18,7 +18,7 @@ jobs:
         COMP_DIR: components/mqtt/esp-mqtt
     steps:
        - name: Checkout esp-mqtt
-         uses: actions/checkout@v3
+         uses: actions/checkout@v4
        - name: Build and Test
          shell: bash
          run: |
@@ -66,7 +66,7 @@ jobs:
        - name: Write to Job Summary
          run: cat code-coverage-results.md >> $GITHUB_STEP_SUMMARY
        - name: Upload artifacts
-         uses: actions/upload-artifact@v3
+         uses: actions/upload-artifact@v4
          if: always()
          with:
            name: docs_gcovr

--- a/.github/workflows/run-on-target.yml
+++ b/.github/workflows/run-on-target.yml
@@ -39,7 +39,7 @@ jobs:
                 ip route
                 echo runner_ip ="`ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}'`" >> "$GITHUB_OUTPUT"
           - name: Checkout IDF ${{inputs.idf_version}}
-            uses: actions/checkout@v3
+            uses: actions/checkout@v4
             with:
                 repository: espressif/esp-idf
                 path: ${{env.IDF_PATH}}
@@ -49,7 +49,7 @@ jobs:
               PIP_EXTRA_INDEX_URL: "https://dl.espressif.com/pypi/"
             run: |
                 pip install --only-binary cryptography -r ${{env.IDF_PATH}}/tools/requirements/requirements.pytest.txt
-          - uses: actions/download-artifact@v3
+          - uses: actions/download-artifact@v4
             with:
               name: mqtt_bin_${{inputs.target}}_${{ inputs.idf_version }}_${{ inputs.app_name }}
               path: build
@@ -57,7 +57,7 @@ jobs:
           - name: Run ${{inputs.app_name}} application on ${{inputs.target}}
             run: |
                 python -m pytest ${{inputs.app_path}} --log-cli-level DEBUG --app-path . --junit-xml=./results_${{inputs.app_name}}_${{inputs.idf_version}}.xml --target=${{inputs.target}}
-          - uses: actions/upload-artifact@v3
+          - uses: actions/upload-artifact@v4
             if: always()
             with:
                 name: results_${{inputs.app_name}}_${{inputs.idf_version}}.xml

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -28,21 +28,7 @@ jobs:
             matrix:
                 idf_version: ["release-v5.0", "release-v5.1", "latest"]
                 target: ["esp32s2", "esp32c3", "esp32s3"]
-                example: [{name: ssl_psk, path: "mqtt/ssl_psk"}]
-        uses: "./.github/workflows/build-app.yml"
-        with:
-            idf_version: ${{matrix.idf_version}}
-            target: ${{matrix.target}}
-            app_name: ${{matrix.example.name}}
-            app_path: $IDF_PATH/examples/protocols/${{matrix.example.path}}
-
-    build-only-ds-example:
-        name: Build Only Apps
-        strategy:
-            matrix:
-                idf_version: ["release-v5.0", "release-v5.1", "latest"]
-                target: ["esp32s2", "esp32c3", "esp32s3"]
-                example: [{name: ssl_ds, path: "mqtt/ssl_ds"}, {name: ssl_psk, path: "mqtt/ssl_psk"}]
+                example: [{name: ssl_psk, path: "mqtt/ssl_psk"}, {name: ssl_ds, path: "mqtt/ssl_ds"}]
         uses: "./.github/workflows/build-app.yml"
         with:
             idf_version: ${{matrix.idf_version}}


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3. It is necessary to update to v4 to make the workflows work.